### PR TITLE
feat: add blog module with Post, Category, and PostCategory models

### DIFF
--- a/prisma/migrations/20260310032726_add_blog_module/migration.sql
+++ b/prisma/migrations/20260310032726_add_blog_module/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "PostStatus" AS ENUM ('RASCUNHO', 'PUBLICADO', 'ARQUIVADO');
+
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" UUID NOT NULL,
+    "title" VARCHAR(255) NOT NULL,
+    "slug" VARCHAR(255) NOT NULL,
+    "summary" VARCHAR(500),
+    "content" TEXT NOT NULL,
+    "coverImageUrl" VARCHAR(500),
+    "status" "PostStatus" NOT NULL DEFAULT 'RASCUNHO',
+    "viewCount" INTEGER NOT NULL DEFAULT 0,
+    "authorId" UUID NOT NULL,
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Category" (
+    "id" UUID NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "slug" VARCHAR(100) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostCategory" (
+    "postId" UUID NOT NULL,
+    "categoryId" UUID NOT NULL,
+
+    CONSTRAINT "PostCategory_pkey" PRIMARY KEY ("postId","categoryId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Post_slug_key" ON "Post"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_name_key" ON "Category"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Category_slug_key" ON "Category"("slug");
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostCategory" ADD CONSTRAINT "PostCategory_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostCategory" ADD CONSTRAINT "PostCategory_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
 
   enrollments     SessionEnrollment[]
   createdSessions Session[] @relation("SessionToUser")
+  posts           Post[]
 }
 
 model Session {
@@ -91,4 +92,49 @@ model SessionEnrollment {
   createdAt DateTime @default(now())
 
   @@unique([userId, sessionId])
+}
+
+enum PostStatus {
+  RASCUNHO
+  PUBLICADO
+  ARQUIVADO
+}
+
+model Post {
+  id            String     @id @default(uuid()) @db.Uuid
+  title         String     @db.VarChar(255)
+  slug          String     @unique @db.VarChar(255)
+  summary       String?    @db.VarChar(500)
+  content       String     @db.Text
+  coverImageUrl String?    @db.VarChar(500)
+  status        PostStatus @default(RASCUNHO)
+  viewCount     Int        @default(0)
+
+  authorId String @db.Uuid
+  author   User   @relation(fields: [authorId], references: [id])
+
+  categories PostCategory[]
+
+  publishedAt DateTime?
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+}
+
+model Category {
+  id        String   @id @default(uuid()) @db.Uuid
+  name      String   @unique @db.VarChar(100)
+  slug      String   @unique @db.VarChar(100)
+  createdAt DateTime @default(now())
+
+  posts PostCategory[]
+}
+
+model PostCategory {
+  postId     String @db.Uuid
+  categoryId String @db.Uuid
+
+  post     Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  category Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+
+  @@id([postId, categoryId])
 }


### PR DESCRIPTION
# Descrição

Adiciona os modelos de banco de dados necessários para o módulo de Blog/Notícias ao schema do Prisma e aplica a migration correspondente.

O sistema atualmente conta com gestão de usuários e sessões, mas não possui infraestrutura para publicação de conteúdo editorial. Esta PR introduz os modelos Post, Category e PostCategory, além do enum PostStatus, preparando o banco para as issues de implementação do módulo blog (Sprint 11).

Nenhuma lógica de aplicação foi alterada — esta PR é exclusivamente de schema e migration.

Essa PR tem como dependências as tarefas de planejamento do módulo blog.

## Tipo de Alterações

Marque o tipo de alterações realizadas:

- [ ] Correção de bug (alteração que corrige um problema)
- [x] Novo recurso (adição de novas funcionalidades)
- [ ] Refatoração (uma mudança no código que não corrige um problema nem adiciona novas funcionalidades)
- [ ] Breaking change (correção ou nova funcionalidade que pode causar mau funcionamento de outras funcionalidades existentes)

## Como Testar

```bash
# 1. Suba o banco
docker compose up -d postgres

# 2. Aplique as migrations
npx prisma migrate deploy

# 3. Valide o schema
npx prisma validate

# 4. Verifique que as tabelas foram criadas
npx prisma studio

# ou conecte direto:
# psql postgresql://postgres:1234@localhost:5432/rpg-system-backend
# \dt
```


## Checklist

- [x] O código segue as diretrizes de codificação do projeto
- [x] Realizei a revisão do meu próprio código
- [x] As alterações foram testadas localmente e passaram nos testes
- [x] Minhas mudanças não geram novos "warnings" ou erros no código existente