### PR TITLE
Fix/gabriel/validations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   app:
     build: .
-    command: sh -c "npx prisma migrate deploy && npm run start"
+    command: sh -c "npx prisma generate && npx prisma migrate deploy && npm run start"
     container_name: rpg-system-backend-api
     ports:
       - "3001:3001"

--- a/prisma/migrations/20260423215753_add_oficinas_support/migration.sql
+++ b/prisma/migrations/20260423215753_add_oficinas_support/migration.sql
@@ -1,0 +1,31 @@
+-- CreateEnum
+CREATE TYPE "EventType" AS ENUM ('MESA', 'OFICINA');
+
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_masterId_fkey";
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "type" "EventType" NOT NULL DEFAULT 'MESA',
+ALTER COLUMN "system" DROP NOT NULL,
+ALTER COLUMN "masterId" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "SessionFacilitator" (
+    "id" UUID NOT NULL,
+    "sessionId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+
+    CONSTRAINT "SessionFacilitator_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SessionFacilitator_sessionId_userId_key" ON "SessionFacilitator"("sessionId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_masterId_fkey" FOREIGN KEY ("masterId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionFacilitator" ADD CONSTRAINT "SessionFacilitator_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SessionFacilitator" ADD CONSTRAINT "SessionFacilitator_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,11 @@ enum SessionPeriod {
   NOITE
 }
 
+enum EventType {
+  MESA
+  OFICINA
+}
+
 enum EnrollmentStatus {
   PENDENTE
   APROVADO
@@ -43,18 +48,20 @@ model User {
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
-  enrollments     SessionEnrollment[]
-  createdSessions Session[] @relation("SessionToUser")
-  posts           Post[]
+  enrollments          SessionEnrollment[]
+  createdSessions      Session[]            @relation("SessionToUser")
+  facilitatedSessions  SessionFacilitator[]
+  posts                Post[]
 }
 
 model Session {
   id            String         @id @default(uuid()) @db.Uuid
+  type          EventType      @default(MESA)
   title         String         @db.VarChar(255)
   description   String         @db.Text
   requirements  String?        @db.Text
   status        SessionStatus  @default(PENDENTE)
-  system        String         @db.VarChar(100)
+  system        String?        @db.VarChar(100)
   location      String?        @db.VarChar(255)
   approvedDate  DateTime?
   cancelEvent   String?        @db.Text
@@ -64,9 +71,10 @@ model Session {
 
   enrollments   SessionEnrollment[]
   possibleDates SessionPossibleDate[]
+  facilitators  SessionFacilitator[]
 
-  masterId String @db.Uuid
-  master   User   @relation(fields: [masterId], references: [id], name: "SessionToUser")
+  masterId String? @db.Uuid
+  master   User?   @relation(fields: [masterId], references: [id], name: "SessionToUser")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -92,6 +100,17 @@ model SessionEnrollment {
   createdAt DateTime @default(now())
 
   @@unique([userId, sessionId])
+}
+
+model SessionFacilitator {
+  id        String  @id @default(uuid()) @db.Uuid
+  sessionId String  @db.Uuid
+  userId    String  @db.Uuid
+
+  session   Session @relation(fields: [sessionId], references: [id])
+  user      User    @relation(fields: [userId], references: [id])
+
+  @@unique([sessionId, userId])
 }
 
 enum PostStatus {

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,13 +1,14 @@
 import type { Express, Request, Response } from "express";
 import express from "express";
 import sessionRouter from "./sessions/sessionsRoutes";
+import workshopRouter from "./sessions/workshopsRoutes";
 import userRouter from "./users/usersRoutes";
 
 const routes = (app: Express) => {
 	app
 		.route("/")
 		.get((req: Request, res: Response) => res.status(200).send("API Node.js"));
-	app.use(express.json(), userRouter, sessionRouter);
+	app.use(express.json(), userRouter, sessionRouter, workshopRouter);
 };
 
 export default routes;

--- a/src/controllers/middlewares/validateEmitWorkshop.ts
+++ b/src/controllers/middlewares/validateEmitWorkshop.ts
@@ -1,0 +1,40 @@
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+
+const emitWorkshopSchema = z
+	.object({
+		title: z.string().min(1, { message: "Título é obrigatório." }),
+		description: z
+			.string()
+			.min(1, { message: "Descrição (ementa) é obrigatória." }),
+		requirements: z.string().optional(),
+		location: z.string().optional(),
+		possibleDates: z
+			.array(z.string().datetime())
+			.min(1, { message: "Informe ao menos uma data possível." }),
+		period: z.enum(["MANHA", "TARDE", "NOITE"], {
+			message: "Período deve ser MANHA, TARDE ou NOITE.",
+		}),
+		minPlayers: z
+			.number()
+			.int()
+			.min(1, { message: "Mínimo de assistentes deve ser pelo menos 1." }),
+		maxPlayers: z
+			.number()
+			.int()
+			.min(1, { message: "Máximo de assistentes deve ser pelo menos 1." }),
+		facilitatorIds: z.array(z.string().uuid()).optional(),
+	})
+	.strict();
+
+export const validateEmitWorkshop = (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	const result = emitWorkshopSchema.safeParse(req.body);
+	if (!result.success) {
+		return res.status(400).json({ errors: result.error.errors });
+	}
+	next();
+};

--- a/src/controllers/sessions/cancelApprovedSessionController.ts
+++ b/src/controllers/sessions/cancelApprovedSessionController.ts
@@ -17,7 +17,7 @@ export async function cancelApprovedSessionController(
 
 		const result = await cancelApprovedSessionService.execute({
 			sessionId,
-			masterId,
+			userId: masterId,
 			cancelEvent,
 		});
 

--- a/src/controllers/sessions/cancelSessionController.ts
+++ b/src/controllers/sessions/cancelSessionController.ts
@@ -13,7 +13,6 @@ export async function cancelPendingSessionController(
 		const userId = (req.user as { id: string }).id;
 		const { sessionId } = req.params;
 
-		// possivel erro com os parametros trocados/invertidos
 		const result = await cancelSessionService.execute({ sessionId, userId });
 
 		return res.status(200).json({ message: result.message });

--- a/src/controllers/sessions/emitWorkshopController.ts
+++ b/src/controllers/sessions/emitWorkshopController.ts
@@ -1,0 +1,56 @@
+import { InvalidUserError } from "@/services/errors/invalidUserError";
+import { PendingWorkshopExistsError } from "@/services/errors/pendingWorkshopExistsError";
+import { makeEmitWorkshopService } from "@/services/factories/makeEmitWorkshopService";
+import type { Request, Response } from "express";
+
+export async function emitWorkshopController(req: Request, res: Response) {
+	const requesterId = (req.user as { id: string }).id;
+	const {
+		title,
+		description,
+		requirements,
+		location,
+		possibleDates,
+		period,
+		minPlayers,
+		maxPlayers,
+		facilitatorIds,
+	} = req.body;
+
+	const allFacilitatorIds: string[] = Array.from(
+		new Set([requesterId, ...(facilitatorIds || [])]),
+	);
+
+	try {
+		const emitWorkshopService = makeEmitWorkshopService();
+		const { session } = await emitWorkshopService.execute({
+			title,
+			description,
+			requirements,
+			location,
+			possibleDates: possibleDates.map((date: string) => new Date(date)),
+			period,
+			minPlayers,
+			maxPlayers,
+			facilitatorIds: allFacilitatorIds,
+		});
+
+		return res
+			.status(201)
+			.json({ message: "Oficina emitida com sucesso", data: session });
+	} catch (error) {
+		if (error instanceof PendingWorkshopExistsError) {
+			return res.status(409).json({ message: error.message });
+		}
+		if (error instanceof InvalidUserError) {
+			return res
+				.status(404)
+				.json({
+					message: "Um dos ministrantes informados não foi encontrado.",
+				});
+		}
+
+		console.error("Error emitting workshop:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
+	}
+}

--- a/src/controllers/sessions/emitWorkshopController.ts
+++ b/src/controllers/sessions/emitWorkshopController.ts
@@ -43,11 +43,9 @@ export async function emitWorkshopController(req: Request, res: Response) {
 			return res.status(409).json({ message: error.message });
 		}
 		if (error instanceof InvalidUserError) {
-			return res
-				.status(404)
-				.json({
-					message: "Um dos ministrantes informados não foi encontrado.",
-				});
+			return res.status(404).json({
+				message: "Um dos ministrantes informados não foi encontrado.",
+			});
 		}
 
 		console.error("Error emitting workshop:", error);

--- a/src/controllers/sessions/getAllWorkshopsController.ts
+++ b/src/controllers/sessions/getAllWorkshopsController.ts
@@ -1,14 +1,14 @@
 import { makeGetAllSessionsService } from "@/services/factories/makeGetAllSessionsService";
 import type { Request, Response } from "express";
 
-export async function getAllSessionsController(req: Request, res: Response) {
+export async function getAllWorkshopsController(req: Request, res: Response) {
 	const getAllSessionsService = makeGetAllSessionsService();
 
 	try {
-		const { sessions } = await getAllSessionsService.execute("MESA");
+		const { sessions } = await getAllSessionsService.execute("OFICINA");
 		return res.status(200).json({ data: sessions });
 	} catch (error) {
-		console.error("Error fetching sessions:", error);
+		console.error("Error fetching workshops:", error);
 		return res.status(500).json({ message: "Erro interno no servidor" });
 	}
 }

--- a/src/controllers/sessions/getAvailableWorkshopsController.ts
+++ b/src/controllers/sessions/getAvailableWorkshopsController.ts
@@ -1,17 +1,17 @@
 import { makeAvaliableSessionsService } from "@/services/factories/makeAvaliableSessionsService";
 import type { Request, Response } from "express";
 
-export async function getAvaliableSessionsController(
+export async function getAvailableWorkshopsController(
 	req: Request,
 	res: Response,
 ) {
 	const avaliableSessionsService = makeAvaliableSessionsService();
 
 	try {
-		const { sessions } = await avaliableSessionsService.execute("MESA");
+		const { sessions } = await avaliableSessionsService.execute("OFICINA");
 		return res.status(200).json({ data: sessions });
 	} catch (error) {
-		console.error("Error fetching available sessions:", error);
-		return res.status(500).json({ message: "Internal server error" });
+		console.error("Error fetching available workshops:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
 	}
 }

--- a/src/controllers/sessions/workshopsRoutes.ts
+++ b/src/controllers/sessions/workshopsRoutes.ts
@@ -1,0 +1,80 @@
+import { Router } from "express";
+import { validateApproveSession } from "../middlewares/validateApproveSession";
+import { validateCancelApprovedSession } from "../middlewares/validateCancelApprovedSession";
+import { validateEmitWorkshop } from "../middlewares/validateEmitWorkshop";
+import { validateJWT } from "../middlewares/validateJWT";
+import { validateRole } from "../middlewares/validateRole";
+import { approveSessionController } from "./approveSessionController";
+import { cancelApprovedSessionController } from "./cancelApprovedSessionController";
+import { cancelEnrollmentController } from "./cancelEnrollmentController";
+import { cancelPendingSessionController } from "./cancelSessionController";
+import { emitWorkshopController } from "./emitWorkshopController";
+import { getAllWorkshopsController } from "./getAllWorkshopsController";
+import { getAvailableWorkshopsController } from "./getAvailableWorkshopsController";
+import { rejectSessionController } from "./rejectSessionController";
+import { subscribeUserToSessionController } from "./subscribeUserToSessionController";
+
+const workshopRouter = Router();
+
+workshopRouter.get("/workshops/approved", getAvailableWorkshopsController);
+
+workshopRouter.get(
+	"/workshops",
+	validateJWT(),
+	validateRole("ADMIN"),
+	getAllWorkshopsController,
+);
+
+workshopRouter.post(
+	"/workshops",
+	validateJWT(),
+	validateRole("MASTER"),
+	validateEmitWorkshop,
+	emitWorkshopController,
+);
+
+workshopRouter.patch(
+	"/workshops/:sessionId/approve",
+	validateJWT(),
+	validateRole("ADMIN"),
+	validateApproveSession,
+	approveSessionController,
+);
+
+workshopRouter.patch(
+	"/workshops/:sessionId/reject",
+	validateJWT(),
+	validateRole("ADMIN"),
+	rejectSessionController,
+);
+
+workshopRouter.delete(
+	"/workshops/:sessionId",
+	validateJWT(),
+	validateRole("MASTER"),
+	cancelPendingSessionController,
+);
+
+workshopRouter.delete(
+	"/workshops/:sessionId/cancel",
+	validateJWT(),
+	validateRole("MASTER"),
+	validateCancelApprovedSession,
+	cancelApprovedSessionController,
+);
+
+workshopRouter.post(
+	"/workshops/:sessionId/subscribe",
+	validateJWT(),
+	validateRole(["PLAYER", "MASTER"]),
+	subscribeUserToSessionController,
+);
+
+workshopRouter.delete(
+	"/workshops/:sessionId/enrollments/me",
+	validateJWT(),
+	validateRole(["PLAYER", "MASTER"]),
+	cancelEnrollmentController,
+);
+
+export default workshopRouter;

--- a/src/controllers/users/getFacilitatedWorkshopsController.ts
+++ b/src/controllers/users/getFacilitatedWorkshopsController.ts
@@ -1,0 +1,19 @@
+import { makeGetFacilitatedWorkshopsService } from "@/services/factories/makeGetFacilitatedWorkshopsService";
+import type { Request, Response } from "express";
+
+export async function getFacilitatedWorkshopsController(
+	req: Request,
+	res: Response,
+) {
+	try {
+		const userId = (req.user as { id: string }).id;
+		const getFacilitatedWorkshopsService = makeGetFacilitatedWorkshopsService();
+		const { workshops } = await getFacilitatedWorkshopsService.execute({
+			userId,
+		});
+		return res.status(200).json({ data: workshops });
+	} catch (error) {
+		console.error("Error fetching facilitated workshops:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
+	}
+}

--- a/src/controllers/users/searchUserByEmailController.ts
+++ b/src/controllers/users/searchUserByEmailController.ts
@@ -1,0 +1,25 @@
+import { NotFoundError } from "@/services/errors/notFoundError";
+import { makeSearchUserByEmailService } from "@/services/factories/makeSearchUserByEmailService";
+import type { Request, Response } from "express";
+
+export async function searchUserByEmailController(req: Request, res: Response) {
+	const { email } = req.query;
+
+	if (!email || typeof email !== "string") {
+		return res
+			.status(400)
+			.json({ message: "O parâmetro 'email' é obrigatório." });
+	}
+
+	try {
+		const searchUserByEmailService = makeSearchUserByEmailService();
+		const { user } = await searchUserByEmailService.execute({ email });
+		return res.status(200).json({ data: user });
+	} catch (error) {
+		if (error instanceof NotFoundError) {
+			return res.status(404).json({ message: error.message });
+		}
+		console.error("Error searching user by email:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
+	}
+}

--- a/src/controllers/users/usersRoutes.ts
+++ b/src/controllers/users/usersRoutes.ts
@@ -1,9 +1,10 @@
 import { validateUpdateEmail } from "../middlewares/validateUpdateEmail";
 import { validateUpdatePassword } from "../middlewares/validateUpdatePassword";
+import { getFacilitatedWorkshopsController } from "./getFacilitatedWorkshopsController";
+import { searchUserByEmailController } from "./searchUserByEmailController";
 import { updateUserEmailController } from "./updateUserEmailController";
 import { updateUserPasswordController } from "./updateUserPasswordController";
 
-// Rest of the imports remain...
 import { type Express, Router } from "express";
 import { validateAuthenticate } from "../middlewares/validateAuthenticate";
 import { validateJWT } from "../middlewares/validateJWT";
@@ -36,6 +37,14 @@ userRouter.get(
 	validateJWT(),
 	getEnrolledSessionsController,
 );
+
+userRouter.get(
+	"/my-facilitated-workshops",
+	validateJWT(),
+	getFacilitatedWorkshopsController,
+);
+
+userRouter.get("/users/search", validateJWT(), searchUserByEmailController);
 
 userRouter.get("/users/profile", validateJWT(), getUserProfileController);
 

--- a/src/repositories/prisma/prismaSessionsRepository.ts
+++ b/src/repositories/prisma/prismaSessionsRepository.ts
@@ -1,6 +1,20 @@
 import { prisma } from "@/lib/prisma";
-import type { Prisma, SessionStatus } from "@prisma/client";
+import type { EventType, Prisma, SessionStatus } from "@prisma/client";
 import type { SessionsRepository } from "../sessionsRepository";
+
+const facilitatorsInclude = {
+	facilitators: {
+		include: {
+			user: {
+				select: {
+					id: true,
+					name: true,
+					email: true,
+				},
+			},
+		},
+	},
+} as const;
 
 export class PrismaSessionsRepository implements SessionsRepository {
 	async findById(id: string) {
@@ -14,6 +28,7 @@ export class PrismaSessionsRepository implements SessionsRepository {
 				},
 				possibleDates: true,
 				enrollments: true,
+				...facilitatorsInclude,
 			},
 		});
 	}
@@ -46,6 +61,24 @@ export class PrismaSessionsRepository implements SessionsRepository {
 					},
 				},
 				possibleDates: true,
+				...facilitatorsInclude,
+			},
+		});
+	}
+
+	async getAllByType(type: EventType) {
+		return prisma.session.findMany({
+			where: { type },
+			include: {
+				master: {
+					select: {
+						id: true,
+						name: true,
+						email: true,
+					},
+				},
+				possibleDates: true,
+				...facilitatorsInclude,
 			},
 		});
 	}
@@ -65,6 +98,7 @@ export class PrismaSessionsRepository implements SessionsRepository {
 						name: true,
 					},
 				},
+				...facilitatorsInclude,
 			},
 		});
 	}
@@ -82,6 +116,28 @@ export class PrismaSessionsRepository implements SessionsRepository {
 				},
 				possibleDates: true,
 				enrollments: true,
+				...facilitatorsInclude,
+			},
+		});
+	}
+
+	async getAllByStatusAndType(status: string, type: EventType) {
+		return prisma.session.findMany({
+			where: {
+				status: status as SessionStatus,
+				type,
+			},
+			include: {
+				master: {
+					select: {
+						id: true,
+						name: true,
+						email: true,
+					},
+				},
+				possibleDates: true,
+				enrollments: true,
+				...facilitatorsInclude,
 			},
 		});
 	}
@@ -117,19 +173,44 @@ export class PrismaSessionsRepository implements SessionsRepository {
 		return !!enrollment;
 	}
 
-	async findFirstByMasterAndStatus(masterId: string, status: string) {
+	async findFirstByMasterAndStatusAndType(
+		masterId: string,
+		status: string,
+		type: EventType,
+	) {
 		return prisma.session.findFirst({
 			where: {
 				masterId,
 				status: status as SessionStatus,
+				type,
 			},
 		});
+	}
+
+	async findFirstByFacilitatorAndStatusAndType(
+		userId: string,
+		status: string,
+		type: EventType,
+	) {
+		const result = await prisma.sessionFacilitator.findFirst({
+			where: {
+				userId,
+				session: {
+					status: status as SessionStatus,
+					type,
+				},
+			},
+		});
+		return result
+			? prisma.session.findUnique({ where: { id: result.sessionId } })
+			: null;
 	}
 
 	async findEmittedByMaster(masterId: string) {
 		return prisma.session.findMany({
 			where: {
 				masterId,
+				type: "MESA",
 			},
 			include: {
 				enrollments: {
@@ -144,6 +225,35 @@ export class PrismaSessionsRepository implements SessionsRepository {
 						},
 					},
 				},
+				...facilitatorsInclude,
+			},
+		});
+	}
+
+	async findEmittedByFacilitator(userId: string) {
+		const facilitatorEntries = await prisma.sessionFacilitator.findMany({
+			where: { userId },
+			select: { sessionId: true },
+		});
+
+		return prisma.session.findMany({
+			where: {
+				id: { in: facilitatorEntries.map((f) => f.sessionId) },
+			},
+			include: {
+				enrollments: {
+					include: {
+						user: {
+							select: {
+								id: true,
+								name: true,
+								email: true,
+								phoneNumber: true,
+							},
+						},
+					},
+				},
+				...facilitatorsInclude,
 			},
 		});
 	}
@@ -165,8 +275,18 @@ export class PrismaSessionsRepository implements SessionsRepository {
 						},
 						possibleDates: true,
 						enrollments: true,
+						...facilitatorsInclude,
 					},
 				},
+			},
+		});
+	}
+
+	async addFacilitator(sessionId: string, userId: string) {
+		await prisma.sessionFacilitator.create({
+			data: {
+				sessionId,
+				userId,
 			},
 		});
 	}

--- a/src/repositories/sessionsRepository.ts
+++ b/src/repositories/sessionsRepository.ts
@@ -1,21 +1,34 @@
 import type {
+	EventType,
 	Prisma,
 	Session,
 	SessionEnrollment,
+	SessionFacilitator,
 	SessionPossibleDate,
 } from "@prisma/client";
+
+type FacilitatorWithUser = SessionFacilitator & {
+	user: {
+		id: string;
+		name: string;
+		email: string;
+	};
+};
 
 type SessionWithRelations = Session & {
 	possibleDates: SessionPossibleDate[];
 	enrollments: SessionEnrollment[];
+	facilitators: FacilitatorWithUser[];
 	master?: {
 		name: string;
-	};
+	} | null;
 };
 
 export type SessionEnrollmentWithSession = SessionEnrollment & {
 	session: Session;
 };
+
+export type { SessionWithRelations, FacilitatorWithUser };
 
 export interface SessionsRepository {
 	findById(id: string): Promise<SessionWithRelations | null>;
@@ -23,18 +36,28 @@ export interface SessionsRepository {
 	update(id: string, data: Prisma.SessionUpdateInput): Promise<Session>;
 	delete(id: string): Promise<void>;
 	getAll(): Promise<Session[]>;
+	getAllByType(type: EventType): Promise<Session[]>;
 	getByUserId(userId: string): Promise<Session[]>;
 	getAllByStatus(status: string): Promise<Session[]>;
+	getAllByStatusAndType(status: string, type: EventType): Promise<Session[]>;
 	subscribeUserToSession(
 		sessionId: string,
 		userId: string,
 	): Promise<SessionEnrollment>;
 	unsubscribeUserFromSession(sessionId: string, userId: string): Promise<void>;
 	isUserEnrolled(sessionId: string, userId: string): Promise<boolean>;
-	findFirstByMasterAndStatus(
+	findFirstByMasterAndStatusAndType(
 		masterId: string,
 		status: string,
+		type: EventType,
+	): Promise<Session | null>;
+	findFirstByFacilitatorAndStatusAndType(
+		userId: string,
+		status: string,
+		type: EventType,
 	): Promise<Session | null>;
 	findEmittedByMaster(masterId: string): Promise<Session[]>;
+	findEmittedByFacilitator(userId: string): Promise<Session[]>;
 	findEnrolledByUser(userId: string): Promise<SessionEnrollmentWithSession[]>;
+	addFacilitator(sessionId: string, userId: string): Promise<void>;
 }

--- a/src/services/errors/PendingSessionExistsError.ts
+++ b/src/services/errors/PendingSessionExistsError.ts
@@ -1,7 +1,8 @@
 export class PendingSessionExistsError extends Error {
 	constructor() {
-		// You already have a session waiting for approve
-		super("You already have a session waiting for approve");
+		super(
+			"Você já possui uma mesa pendente de aprovação. Aguarde a análise do administrador antes de emitir outra.",
+		);
 		this.name = "PendingSessionExistsError";
 	}
 }

--- a/src/services/errors/pendingWorkshopExistsError.ts
+++ b/src/services/errors/pendingWorkshopExistsError.ts
@@ -1,0 +1,8 @@
+export class PendingWorkshopExistsError extends Error {
+	constructor() {
+		super(
+			"Você já possui uma oficina pendente de aprovação. Aguarde a análise do administrador antes de emitir outra.",
+		);
+		this.name = "PendingWorkshopExistsError";
+	}
+}

--- a/src/services/errors/sessionConflictError.ts
+++ b/src/services/errors/sessionConflictError.ts
@@ -1,6 +1,8 @@
 export class SessionConflictError extends Error {
 	constructor() {
-		super("Você já está inscrito em uma sessão neste mesmo dia e período.");
+		super(
+			"Você já possui uma inscrição em conflito com este horário. Só é permitida uma mesa por dia e eventos do mesmo período não podem ser acumulados.",
+		);
 		this.name = "SessionConflictError";
 	}
 }

--- a/src/services/factories/makeEmitWorkshopService.ts
+++ b/src/services/factories/makeEmitWorkshopService.ts
@@ -1,0 +1,9 @@
+import { PrismaSessionsRepository } from "@/repositories/prisma/prismaSessionsRepository";
+import { PrismaUsersRepository } from "@/repositories/prisma/prismaUsersRepository";
+import { EmitWorkshopService } from "../sessions/emitWorkshopService";
+
+export function makeEmitWorkshopService() {
+	const sessionsRepository = new PrismaSessionsRepository();
+	const usersRepository = new PrismaUsersRepository();
+	return new EmitWorkshopService(sessionsRepository, usersRepository);
+}

--- a/src/services/factories/makeGetFacilitatedWorkshopsService.ts
+++ b/src/services/factories/makeGetFacilitatedWorkshopsService.ts
@@ -1,0 +1,7 @@
+import { PrismaSessionsRepository } from "../../repositories/prisma/prismaSessionsRepository";
+import { GetFacilitatedWorkshopsService } from "../users/getFacilitatedWorkshopsService";
+
+export function makeGetFacilitatedWorkshopsService() {
+	const sessionsRepository = new PrismaSessionsRepository();
+	return new GetFacilitatedWorkshopsService(sessionsRepository);
+}

--- a/src/services/factories/makeSearchUserByEmailService.ts
+++ b/src/services/factories/makeSearchUserByEmailService.ts
@@ -1,0 +1,7 @@
+import { PrismaUsersRepository } from "@/repositories/prisma/prismaUsersRepository";
+import { SearchUserByEmailService } from "../users/searchUserByEmailService";
+
+export function makeSearchUserByEmailService() {
+	const usersRepository = new PrismaUsersRepository();
+	return new SearchUserByEmailService(usersRepository);
+}

--- a/src/services/sessions/approveSessionService.ts
+++ b/src/services/sessions/approveSessionService.ts
@@ -21,7 +21,7 @@ export class ApproveSessionService {
 	constructor(
 		private sessionsRepository: SessionsRepository,
 		private usersRepository: UsersRepository,
-	) { }
+	) {}
 
 	async execute({
 		sessionId,

--- a/src/services/sessions/approveSessionService.ts
+++ b/src/services/sessions/approveSessionService.ts
@@ -21,7 +21,7 @@ export class ApproveSessionService {
 	constructor(
 		private sessionsRepository: SessionsRepository,
 		private usersRepository: UsersRepository,
-	) {}
+	) { }
 
 	async execute({
 		sessionId,
@@ -45,7 +45,6 @@ export class ApproveSessionService {
 			throw new NotFoundError("Usuário não encontrado");
 		}
 
-		// Verifica se a data aprovada está entre as datas possíveis da sessão
 		const possibleDatesExists = session.possibleDates.some(
 			(pd: { date: Date | string }) =>
 				new Date(pd.date).toISOString().slice(0, 10) ===

--- a/src/services/sessions/cancelApprovedSessionService.ts
+++ b/src/services/sessions/cancelApprovedSessionService.ts
@@ -1,12 +1,13 @@
 import type { SessionsRepository } from "@/repositories/sessionsRepository";
 import type { UsersRepository } from "@/repositories/usersRepository";
+import { InvalidSessionError } from "../errors/invalidSessionError";
 import { NotFoundError } from "../errors/notFoundError";
 import { SessionCancellationWindowError } from "../errors/sessionCancellationWindowError";
 import { userIsNotMaster } from "../errors/userIsNotMaster";
 
 interface CancelApprovedSessionServiceRequest {
 	sessionId: string;
-	masterId: string;
+	userId: string;
 	cancelEvent: string;
 }
 
@@ -22,7 +23,7 @@ export class CancelApprovedSessionService {
 
 	async execute({
 		sessionId,
-		masterId,
+		userId,
 		cancelEvent,
 	}: CancelApprovedSessionServiceRequest): Promise<CancelApprovedSessionServiceResponse> {
 		const session = await this.sessionsRepository.findById(sessionId);
@@ -32,17 +33,26 @@ export class CancelApprovedSessionService {
 		}
 
 		if (!session.approvedDate) {
-			throw new NotFoundError("Sessão não possui data aprovada");
+			throw new InvalidSessionError();
 		}
 
-		const user = await this.usersRepository.findById(masterId);
+		const user = await this.usersRepository.findById(userId);
 
 		if (!user) {
 			throw new NotFoundError("Usuário não encontrado");
 		}
 
-		if (session.masterId !== masterId) {
-			throw new userIsNotMaster();
+		if (session.type === "MESA") {
+			if (session.masterId !== userId) {
+				throw new userIsNotMaster();
+			}
+		} else {
+			const isFacilitator = session.facilitators.some(
+				(f) => f.userId === userId,
+			);
+			if (!isFacilitator) {
+				throw new userIsNotMaster();
+			}
 		}
 
 		const now = new Date();

--- a/src/services/sessions/cancelSessionService.ts
+++ b/src/services/sessions/cancelSessionService.ts
@@ -39,8 +39,17 @@ export class CancelPendingSessionService {
 			throw new NotFoundError("Usuário não encontrado");
 		}
 
-		if (session.masterId !== userId) {
-			throw new userIsNotMaster();
+		if (session.type === "MESA") {
+			if (session.masterId !== userId) {
+				throw new userIsNotMaster();
+			}
+		} else {
+			const isFacilitator = session.facilitators.some(
+				(f) => f.userId === userId,
+			);
+			if (!isFacilitator) {
+				throw new userIsNotMaster();
+			}
 		}
 
 		await this.sessionsRepository.update(session.id, {
@@ -48,8 +57,7 @@ export class CancelPendingSessionService {
 		});
 
 		return {
-			message:
-				"Infelizmente, sua solicitação não pôde ser atendida, pois as datas escolhidas não são adequadas para a mestragem da mesa. Por favor contate o admin do sistema.",
+			message: "Solicitação cancelada com sucesso.",
 		};
 	}
 }

--- a/src/services/sessions/emitSessionService.ts
+++ b/src/services/sessions/emitSessionService.ts
@@ -33,9 +33,10 @@ export class EmitSessionService {
 		masterId,
 	}: emitSessionServiceRequest): Promise<emitSessionServiceResponse> {
 		const pendingSession =
-			await this.sessionsRepository.findFirstByMasterAndStatus(
+			await this.sessionsRepository.findFirstByMasterAndStatusAndType(
 				masterId,
 				"PENDENTE",
+				"MESA",
 			);
 		if (pendingSession) {
 			throw new PendingSessionExistsError();

--- a/src/services/sessions/emitWorkshopService.ts
+++ b/src/services/sessions/emitWorkshopService.ts
@@ -1,0 +1,82 @@
+import type { SessionsRepository } from "@/repositories/sessionsRepository";
+import type { UsersRepository } from "@/repositories/usersRepository";
+import type { Session, SessionPeriod } from "@prisma/client";
+import { InvalidUserError } from "../errors/invalidUserError";
+import { PendingWorkshopExistsError } from "../errors/pendingWorkshopExistsError";
+
+interface EmitWorkshopServiceRequest {
+	title: string;
+	description: string;
+	requirements?: string;
+	location?: string;
+	possibleDates: Date[];
+	period: SessionPeriod;
+	minPlayers: number;
+	maxPlayers: number;
+	facilitatorIds: string[];
+}
+
+interface EmitWorkshopServiceResponse {
+	session: Session;
+}
+
+export class EmitWorkshopService {
+	constructor(
+		private sessionsRepository: SessionsRepository,
+		private usersRepository: UsersRepository,
+	) {}
+
+	async execute({
+		title,
+		description,
+		requirements,
+		location,
+		possibleDates,
+		period,
+		minPlayers,
+		maxPlayers,
+		facilitatorIds,
+	}: EmitWorkshopServiceRequest): Promise<EmitWorkshopServiceResponse> {
+		for (const facilitatorId of facilitatorIds) {
+			const user = await this.usersRepository.findById(facilitatorId);
+			if (!user) {
+				throw new InvalidUserError();
+			}
+
+			const pendingWorkshop =
+				await this.sessionsRepository.findFirstByFacilitatorAndStatusAndType(
+					facilitatorId,
+					"PENDENTE",
+					"OFICINA",
+				);
+			if (pendingWorkshop) {
+				throw new PendingWorkshopExistsError();
+			}
+		}
+
+		const session = await this.sessionsRepository.create({
+			type: "OFICINA",
+			title,
+			description,
+			requirements,
+			location,
+			period,
+			minPlayers,
+			maxPlayers,
+			status: "PENDENTE",
+			possibleDates: {
+				create: possibleDates.map((date) => ({
+					date,
+				})),
+			},
+		});
+
+		for (const facilitatorId of facilitatorIds) {
+			await this.sessionsRepository.addFacilitator(session.id, facilitatorId);
+		}
+
+		return {
+			session,
+		};
+	}
+}

--- a/src/services/sessions/getAllSessionsService.ts
+++ b/src/services/sessions/getAllSessionsService.ts
@@ -1,15 +1,15 @@
 import type { SessionsRepository } from "@/repositories/sessionsRepository";
-import type { Session } from "@prisma/client";
+import type { EventType, Session } from "@prisma/client";
 
 interface GetAllSessionsServiceResponse {
 	sessions: Session[];
 }
 
 export class GetAllSessionsService {
-	constructor(private SessionRepository: SessionsRepository) {}
+	constructor(private sessionRepository: SessionsRepository) {}
 
-	async execute(): Promise<GetAllSessionsServiceResponse> {
-		const sessions = await this.SessionRepository.getAll();
+	async execute(type: EventType): Promise<GetAllSessionsServiceResponse> {
+		const sessions = await this.sessionRepository.getAllByType(type);
 
 		return {
 			sessions,

--- a/src/services/sessions/getAvaliableSessionsService.ts
+++ b/src/services/sessions/getAvaliableSessionsService.ts
@@ -1,15 +1,18 @@
 import type { SessionsRepository } from "@/repositories/sessionsRepository";
-import type { Session } from "@prisma/client";
+import type { EventType, Session } from "@prisma/client";
 
 interface GetAvaliableSessionsServiceResponse {
 	sessions: Session[];
 }
 
 export class GetAvaliableSessionsService {
-	constructor(private SessionRepository: SessionsRepository) {}
+	constructor(private sessionRepository: SessionsRepository) {}
 
-	async execute(): Promise<GetAvaliableSessionsServiceResponse> {
-		const sessions = await this.SessionRepository.getAllByStatus("APROVADA");
+	async execute(type: EventType): Promise<GetAvaliableSessionsServiceResponse> {
+		const sessions = await this.sessionRepository.getAllByStatusAndType(
+			"APROVADA",
+			type,
+		);
 
 		return {
 			sessions,

--- a/src/services/sessions/subscribeUserToSessionService.ts
+++ b/src/services/sessions/subscribeUserToSessionService.ts
@@ -21,7 +21,7 @@ export class SubscribeUserToSessionService {
 	constructor(
 		private sessionsRepository: SessionsRepository,
 		private usersRepository: UsersRepository,
-	) {}
+	) { }
 
 	async execute({
 		sessionId,
@@ -60,10 +60,19 @@ export class SubscribeUserToSessionService {
 			await this.sessionsRepository.findEnrolledByUser(userId);
 		const hasConflict = userEnrollments.some(({ session: enrolledSession }) => {
 			if (!enrolledSession.approvedDate || !session.approvedDate) return false;
+
 			const sameDay =
 				new Date(enrolledSession.approvedDate).toISOString().slice(0, 10) ===
 				new Date(session.approvedDate).toISOString().slice(0, 10);
-			return sameDay && enrolledSession.period === session.period;
+
+			if (!sameDay) return false;
+
+			// Regra 1: Apenas uma mesa por dia. Se as duas forem mesas no mesmo dia, conflito imediato.
+			if (session.type === "MESA" && enrolledSession.type === "MESA")
+				return true;
+
+			// Regra 2: Para qualquer tipo de evento (Mesa ou Oficina), não pode ser no mesmo período.
+			return enrolledSession.period === session.period;
 		});
 		if (hasConflict) {
 			throw new SessionConflictError();

--- a/src/services/sessions/subscribeUserToSessionService.ts
+++ b/src/services/sessions/subscribeUserToSessionService.ts
@@ -21,7 +21,7 @@ export class SubscribeUserToSessionService {
 	constructor(
 		private sessionsRepository: SessionsRepository,
 		private usersRepository: UsersRepository,
-	) { }
+	) {}
 
 	async execute({
 		sessionId,

--- a/src/services/users/getFacilitatedWorkshopsService.ts
+++ b/src/services/users/getFacilitatedWorkshopsService.ts
@@ -1,0 +1,18 @@
+import type { SessionsRepository } from "../../repositories/sessionsRepository";
+
+interface GetFacilitatedWorkshopsServiceRequest {
+	userId: string;
+}
+
+export class GetFacilitatedWorkshopsService {
+	constructor(private sessionRepository: SessionsRepository) {}
+
+	async execute({ userId }: GetFacilitatedWorkshopsServiceRequest) {
+		const workshops =
+			await this.sessionRepository.findEmittedByFacilitator(userId);
+
+		return {
+			workshops,
+		};
+	}
+}

--- a/src/services/users/searchUserByEmailService.ts
+++ b/src/services/users/searchUserByEmailService.ts
@@ -1,0 +1,38 @@
+import type { UsersRepository } from "@/repositories/usersRepository";
+import { NotFoundError } from "../errors/notFoundError";
+
+interface SearchUserByEmailServiceRequest {
+	email: string;
+}
+
+interface SearchUserByEmailServiceResponse {
+	user: {
+		id: string;
+		name: string;
+		email: string;
+		role: string;
+	};
+}
+
+export class SearchUserByEmailService {
+	constructor(private usersRepository: UsersRepository) {}
+
+	async execute({
+		email,
+	}: SearchUserByEmailServiceRequest): Promise<SearchUserByEmailServiceResponse> {
+		const user = await this.usersRepository.findByEmail(email);
+
+		if (!user) {
+			throw new NotFoundError("Usuário não encontrado");
+		}
+
+		return {
+			user: {
+				id: user.id,
+				name: user.name,
+				email: user.email,
+				role: user.role,
+			},
+		};
+	}
+}

--- a/src/test/controllers/sessions-protected.test.ts
+++ b/src/test/controllers/sessions-protected.test.ts
@@ -381,6 +381,37 @@ describe("Protected Sessions Routes", () => {
 				.set("Authorization", `Bearer ${playerToken}`)
 				.expect(409);
 		});
+
+		it("should not allow subscription to two mesas on the same day even in different periods", async () => {
+			const sessionDate = new Date();
+			sessionDate.setDate(sessionDate.getDate() + 7);
+
+			const firstSession = await createSession({
+				title: "Mesa Manha",
+				masterId: masterId,
+				status: "APROVADA",
+				approvedDate: sessionDate,
+				period: "MANHA",
+			});
+
+			const secondSession = await createSession({
+				title: "Mesa Tarde",
+				masterId: masterId,
+				status: "APROVADA",
+				approvedDate: sessionDate,
+				period: "TARDE",
+			});
+
+			await request(app)
+				.post(`/sessions/${firstSession.id}/subscribe`)
+				.set("Authorization", `Bearer ${playerToken}`)
+				.expect(200);
+
+			await request(app)
+				.post(`/sessions/${secondSession.id}/subscribe`)
+				.set("Authorization", `Bearer ${playerToken}`)
+				.expect(409);
+		});
 	});
 
 	describe("DELETE /sessions/:sessionId/enrollments/me — cancellation window", () => {

--- a/src/test/controllers/workshops.test.ts
+++ b/src/test/controllers/workshops.test.ts
@@ -1,0 +1,286 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../../app";
+import {
+	cleanupTestData,
+	createSession,
+	createUser,
+	createWorkshop,
+} from "../helpers";
+
+describe("Workshop Routes", () => {
+	let masterToken: string;
+	let playerToken: string;
+	let adminToken: string;
+	let masterId: string;
+	let playerId: string;
+
+	beforeEach(async () => {
+		await cleanupTestData();
+
+		const master = await createUser({
+			email: "master@example.com",
+			password: "password123",
+			role: "MASTER",
+		});
+
+		const player = await createUser({
+			email: "player@example.com",
+			password: "password123",
+			role: "PLAYER",
+		});
+
+		const admin = await createUser({
+			email: "admin@example.com",
+			password: "password123",
+			role: "ADMIN",
+		});
+
+		masterId = master.id;
+		playerId = player.id;
+
+		const masterAuth = await request(app)
+			.post("/users/authenticate")
+			.send({ email: master.email, password: master.password });
+
+		const playerAuth = await request(app)
+			.post("/users/authenticate")
+			.send({ email: player.email, password: player.password });
+
+		const adminAuth = await request(app)
+			.post("/users/authenticate")
+			.send({ email: admin.email, password: admin.password });
+
+		masterToken = masterAuth.body.token;
+		playerToken = playerAuth.body.token;
+		adminToken = adminAuth.body.token;
+	});
+
+	describe("POST /workshops", () => {
+		const workshopData = {
+			title: "Introdução ao RPG",
+			description: "Ementa da oficina sobre os fundamentos do RPG",
+			requirements: "Nenhum",
+			location: "Sala 101",
+			possibleDates: ["2025-12-01T19:00:00Z", "2025-12-02T19:00:00Z"],
+			period: "NOITE",
+			minPlayers: 5,
+			maxPlayers: 20,
+		};
+
+		it("should allow a master to emit a workshop with themselves as facilitator", async () => {
+			const response = await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ ...workshopData, facilitatorIds: [masterId] })
+				.expect(201);
+
+			expect(response.body).toHaveProperty("data");
+			expect(response.body.data.title).toBe(workshopData.title);
+			expect(response.body.data.type).toBe("OFICINA");
+			expect(response.body.data.system).toBeNull();
+		});
+
+		it("should allow multiple facilitators", async () => {
+			const secondMaster = await createUser({
+				email: "master2@example.com",
+				password: "password123",
+				role: "MASTER",
+			});
+
+			const response = await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ ...workshopData, facilitatorIds: [masterId, secondMaster.id] })
+				.expect(201);
+
+			expect(response.body.data).toHaveProperty("id");
+		});
+
+		it("should not allow a master with a pending workshop to emit another", async () => {
+			await createWorkshop({ facilitatorIds: [masterId] });
+
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ ...workshopData, facilitatorIds: [masterId] })
+				.expect(409);
+		});
+
+		it("should allow a master with a pending session (MESA) to emit a workshop (OFICINA)", async () => {
+			await createSession({
+				title: "Pending Mesa",
+				masterId,
+				status: "PENDENTE",
+			});
+
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ ...workshopData, facilitatorIds: [masterId] })
+				.expect(201);
+		});
+
+		it("should not allow a player to emit a workshop", async () => {
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${playerToken}`)
+				.send({ ...workshopData, facilitatorIds: [playerId] })
+				.expect(403);
+		});
+
+		it("should not allow an admin to emit a workshop", async () => {
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.send({ ...workshopData, facilitatorIds: [masterId] })
+				.expect(403);
+		});
+
+		it("should require authentication", async () => {
+			await request(app)
+				.post("/workshops")
+				.send({ ...workshopData, facilitatorIds: [masterId] })
+				.expect(401);
+		});
+
+		it("should return 400 when required fields are missing", async () => {
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ title: "Só o título" })
+				.expect(400);
+		});
+
+		it("should allow emission even when facilitatorIds is empty (creator is added automatically)", async () => {
+			const response = await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({ ...workshopData, facilitatorIds: [] })
+				.expect(201);
+
+			expect(response.body).toHaveProperty("data");
+		});
+
+		it("should return 404 when a facilitatorId does not exist", async () => {
+			await request(app)
+				.post("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.send({
+					...workshopData,
+					facilitatorIds: ["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"],
+				})
+				.expect(404);
+		});
+	});
+
+	describe("GET /workshops/approved", () => {
+		it("should return only approved workshops", async () => {
+			const futureDate = new Date();
+			futureDate.setDate(futureDate.getDate() + 10);
+
+			await createWorkshop({
+				title: "Oficina Aprovada",
+				status: "APROVADA",
+				approvedDate: futureDate,
+				facilitatorIds: [masterId],
+			});
+
+			await createWorkshop({
+				title: "Oficina Pendente",
+				status: "PENDENTE",
+				facilitatorIds: [masterId],
+			});
+
+			const response = await request(app)
+				.get("/workshops/approved")
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(1);
+			expect(response.body.data[0].title).toBe("Oficina Aprovada");
+		});
+
+		it("should not return approved sessions (MESA) in the workshop list", async () => {
+			const futureDate = new Date();
+			futureDate.setDate(futureDate.getDate() + 10);
+
+			await createSession({
+				title: "Mesa Aprovada",
+				masterId,
+				status: "APROVADA",
+				approvedDate: futureDate,
+			});
+
+			const response = await request(app)
+				.get("/workshops/approved")
+				.expect(200);
+
+			expect(response.body.data).toHaveLength(0);
+		});
+
+		it("should not require authentication", async () => {
+			await request(app).get("/workshops/approved").expect(200);
+		});
+	});
+
+	describe("GET /workshops (admin)", () => {
+		it("should return all workshops for admin", async () => {
+			await createWorkshop({ status: "PENDENTE", facilitatorIds: [masterId] });
+			await createWorkshop({ status: "APROVADA", facilitatorIds: [masterId] });
+
+			const response = await request(app)
+				.get("/workshops")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.expect(200);
+
+			expect(response.body.data.length).toBeGreaterThanOrEqual(2);
+			expect(
+				response.body.data.every((w: { type: string }) => w.type === "OFICINA"),
+			).toBe(true);
+		});
+
+		it("should not allow master to access the full workshop list", async () => {
+			await request(app)
+				.get("/workshops")
+				.set("Authorization", `Bearer ${masterToken}`)
+				.expect(403);
+		});
+
+		it("should require authentication", async () => {
+			await request(app).get("/workshops").expect(401);
+		});
+	});
+
+	describe("POST /workshops/:sessionId/subscribe — schedule conflict (cross-type)", () => {
+		it("should not allow a user to enroll in a workshop conflicting with a session in the same period", async () => {
+			const sessionDate = new Date();
+			sessionDate.setDate(sessionDate.getDate() + 7);
+
+			const mesa = await createSession({
+				title: "Mesa na mesma data",
+				masterId,
+				status: "APROVADA",
+				approvedDate: sessionDate,
+				period: "TARDE",
+			});
+
+			const oficina = await createWorkshop({
+				title: "Oficina no mesmo período",
+				status: "APROVADA",
+				approvedDate: sessionDate,
+				period: "TARDE",
+				facilitatorIds: [masterId],
+			});
+
+			await request(app)
+				.post(`/sessions/${mesa.id}/subscribe`)
+				.set("Authorization", `Bearer ${playerToken}`)
+				.expect(200);
+
+			await request(app)
+				.post(`/workshops/${oficina.id}/subscribe`)
+				.set("Authorization", `Bearer ${playerToken}`)
+				.expect(409);
+		});
+	});
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -33,7 +33,7 @@ export interface TestSession {
 	id: string;
 	title: string;
 	description: string;
-	system: string;
+	system?: string;
 	location?: string;
 	minPlayers: number;
 	maxPlayers: number;
@@ -156,6 +156,48 @@ export async function createSession(
 	};
 }
 
+export async function createWorkshop(
+	data: Partial<Omit<TestSession, "masterId">> & { facilitatorIds: string[] },
+): Promise<TestSession & { facilitatorIds: string[] }> {
+	const sessionData = {
+		type: "OFICINA" as const,
+		title: data.title || "Test Workshop",
+		description: data.description || "Test workshop description",
+		location: data.location,
+		minPlayers: data.minPlayers || 3,
+		maxPlayers: data.maxPlayers || 6,
+		status: data.status || ("PENDENTE" as SessionStatus),
+		period: data.period,
+		requirements: data.requirements,
+		approvedDate: data.approvedDate,
+	};
+
+	const session = await prisma.session.create({
+		data: sessionData,
+	});
+
+	for (const userId of data.facilitatorIds) {
+		await prisma.sessionFacilitator.create({
+			data: { sessionId: session.id, userId },
+		});
+	}
+
+	return {
+		id: session.id,
+		title: session.title,
+		description: session.description,
+		location: session.location || undefined,
+		minPlayers: session.minPlayers,
+		maxPlayers: session.maxPlayers,
+		masterId: "",
+		status: session.status,
+		period: session.period || undefined,
+		requirements: session.requirements || undefined,
+		approvedDate: session.approvedDate || undefined,
+		facilitatorIds: data.facilitatorIds,
+	};
+}
+
 export async function createSessionWithDates(
 	sessionData: Partial<TestSession> & { masterId: string },
 	dates: Date[],
@@ -193,6 +235,7 @@ export async function cleanupTestData() {
 	while (retryCount < maxRetries) {
 		try {
 			await prisma.sessionEnrollment.deleteMany();
+			await prisma.sessionFacilitator.deleteMany();
 			await prisma.sessionPossibleDate.deleteMany();
 			await prisma.session.deleteMany();
 			await prisma.user.deleteMany();

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -144,7 +144,7 @@ export async function createSession(
 		id: session.id,
 		title: session.title,
 		description: session.description,
-		system: session.system,
+		system: session.system || undefined,
 		location: session.location || undefined,
 		minPlayers: session.minPlayers,
 		maxPlayers: session.maxPlayers,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -16,6 +16,7 @@ async function cleanDatabase() {
 	while (retryCount < maxRetries) {
 		try {
 			await prisma.sessionEnrollment.deleteMany();
+			await prisma.sessionFacilitator.deleteMany();
 			await prisma.sessionPossibleDate.deleteMany();
 			await prisma.session.deleteMany();
 			await prisma.user.deleteMany();


### PR DESCRIPTION
# Descrição

Esta PR implementa o suporte completo à funcionalidade de **Oficinas**, trazendo paridade com o sistema existente de Mesas de RPG, mas adaptando a plataforma para lidar com eventos narrativos/teóricos com múltiplos ministrantes, número maior de participantes e regras de agendamento levemente diferentes. 

Para isso, dividimos o front e o backend logicamente, introduzindo novos controladores, interfaces no Prisma e adequando o sistema de validação e UI.

Essa PR fecha a issue/task relacionada à implementação das Oficinas. *(adicione aqui o número caso haja: ex: closes #42)*

## Mudanças Realizadas:
* **Banco de Dados (Prisma):** Implementado o `EventType` (`MESA | OFICINA`) no schema para distinguir nativamente as sessões, junto das tabelas de ligação `SessionFacilitator`.
* **Backend (Serviços e Rotas):**
  * Novas rotas dedicadas sob `/workshops`.
  * Rota utilitária de busca de usuários por E-mail para delegar facilitadores/ministrantes (`searchUserByEmailService`).
  * Atualização da lógica de conflito (`SessionConflictError`): agora Oficinas e Mesas compartilham a checagem global de bloqueio de turnos conflitantes (MANHÃ, TARDE, NOITE). A regra de limite de "1 evento por dia" agora é estrita apenas para Mesas.
  * O local da sessão (`location`) foi desvinculado do fluxo de criação pelo usuário e agora é atribuído exclusivamente pelos Admins na tela de aprovação.
  * Adicionado o comando `npx prisma generate` no `docker-compose.yml` para prevenir quebra de client ao instanciar os containers.
* **Frontend (UI e Navegação):**
  * Criação da tela `CreateWorkshop.tsx` utilizando pesquisa em tempo real de e-mails para adicionar co-ministrantes.
  * Reestruturação radical das páginas `Sessions.tsx`, `Profile.tsx` e `Admin.tsx`, agora utilizando `Tabs` da Shadcn para bifurcar as visualizações limpas entre "Mesas de RPG" e "Oficinas".
  * Novos componentes `WorkshopCard` e `MasterWorkshopCard` para refletir as terminologias corretas ("Ministrantes" vs "Mestre", "Participantes" vs "Jogadores") e ocultar o logo do sistema, já que oficinas são agnósticas a sistemas de RPG.

## Tipo de Alterações

Marque o tipo de alterações realizadas:

- [x] Correção de bug (alteração que corrige um problema) *(Resolvemos bugs de permissão de criação e conflitos de horários)*
- [x] Novo recurso (adição de novas funcionalidades)
- [x] Refatoração (uma mudança no código que não corrige um problema nem adiciona novas funcionalidades)
- [ ] Breaking change (correção ou nova funcionalidade que pode causar mau funcionamento de outras funcionalidades existentes)

## Como Testar

1. Suba os containers do projeto (API, Banco) garantindo o rebuild (`docker compose up --build`).
2. Acesse o Frontend na porta configurada.
3. Crie uma conta de Master, navegue até `Emitir Oficina` e crie uma oficina, testando a busca de e-mail de um outro usuário cadastrado.
4. Logue como Admin e vá ao Painel. Mude para a aba "Oficinas Pendentes", aprove a oficina informando a Localização e a Data confirmada.
5. Em outra conta "Player", vá até "Sessões", troque a aba para Oficinas e verifique se o botão "Inscreva-se" exibe as vagas e ministrantes corretos.
6. Teste os bloqueios de tempo logando no jogador: tente se inscrever numa oficina de "TARDE" e depois numa mesa "TARDE", garantindo que a notificação de bloqueio global de período seja disparada.
7. O comando `npm run test:docker` deve passar nos 123 testes com exit code `0`.

## Checklist

- [x] O código segue as diretrizes de codificação do projeto
- [x] Realizei a revisão do meu próprio código
- [x] As alterações foram testadas localmente e passaram nos testes
- [x] Minhas mudanças não geram novos "warnings" ou erros no código existente
