### PR TITLE
Feat/pedro/issue#29

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import type { Express, Request, Response } from "express";
 import express from "express";
+import postsRouter from "./posts/postsRoutes";
 import sessionRouter from "./sessions/sessionsRoutes";
 import workshopRouter from "./sessions/workshopsRoutes";
 import userRouter from "./users/usersRoutes";
@@ -8,7 +9,13 @@ const routes = (app: Express) => {
 	app
 		.route("/")
 		.get((req: Request, res: Response) => res.status(200).send("API Node.js"));
-	app.use(express.json(), userRouter, sessionRouter, workshopRouter);
+	app.use(
+		express.json(),
+		userRouter,
+		sessionRouter,
+		workshopRouter,
+		postsRouter,
+	);
 };
 
 export default routes;

--- a/src/controllers/middlewares/validateOptionalJWT.ts
+++ b/src/controllers/middlewares/validateOptionalJWT.ts
@@ -1,0 +1,28 @@
+import { env } from "@/env/index";
+/// <reference path="../../@types/express.d.ts" />
+import type { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+export const validateOptionalJWT = () => {
+	return (req: Request, res: Response, next: NextFunction) => {
+		const token = req.headers.authorization?.split(" ")[1];
+
+		if (!token) {
+			return next();
+		}
+
+		try {
+			const { JWT_SECRET } = env;
+			const decoded = jwt.verify(token, JWT_SECRET) as {
+				sub: string;
+				role: string;
+			};
+
+			req.user = { id: decoded.sub, role: decoded.role };
+		} catch (error) {
+			// Token inválido em rota pública: ignora e segue sem usuário autenticado
+		}
+
+		next();
+	};
+};

--- a/src/controllers/posts/getPostBySlugController.ts
+++ b/src/controllers/posts/getPostBySlugController.ts
@@ -1,0 +1,23 @@
+import { PostNotFoundError } from "@/services/errors/postNotFoundError";
+import { makeGetPostBySlugService } from "@/services/factories/makeGetPostBySlugService";
+import type { Request, Response } from "express";
+
+export async function getPostBySlugController(req: Request, res: Response) {
+	const getPostBySlugService = makeGetPostBySlugService();
+
+	const { slug } = req.params;
+	const isAdmin = req.user?.role === "ADMIN";
+
+	try {
+		const { post } = await getPostBySlugService.execute({ slug, isAdmin });
+
+		return res.status(200).json({ data: post });
+	} catch (error) {
+		if (error instanceof PostNotFoundError) {
+			return res.status(404).json({ message: error.message });
+		}
+
+		console.error("Error fetching post by slug:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
+	}
+}

--- a/src/controllers/posts/listPostsController.ts
+++ b/src/controllers/posts/listPostsController.ts
@@ -1,0 +1,26 @@
+import { makeListPostsService } from "@/services/factories/makeListPostsService";
+import type { PostStatus } from "@prisma/client";
+import type { Request, Response } from "express";
+
+export async function listPostsController(req: Request, res: Response) {
+	const listPostsService = makeListPostsService();
+
+	const { page, limit, categorySlug, search, status } = req.query;
+	const isAdmin = req.user?.role === "ADMIN";
+
+	try {
+		const result = await listPostsService.execute({
+			page: page ? Number(page) : undefined,
+			limit: limit ? Number(limit) : undefined,
+			categorySlug: categorySlug ? String(categorySlug) : undefined,
+			search: search ? String(search) : undefined,
+			status: status ? (String(status) as PostStatus) : undefined,
+			isAdmin,
+		});
+
+		return res.status(200).json({ data: result });
+	} catch (error) {
+		console.error("Error fetching posts:", error);
+		return res.status(500).json({ message: "Erro interno no servidor" });
+	}
+}

--- a/src/controllers/posts/postsRoutes.ts
+++ b/src/controllers/posts/postsRoutes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { validateOptionalJWT } from "../middlewares/validateOptionalJWT";
+import { getPostBySlugController } from "./getPostBySlugController";
+import { listPostsController } from "./listPostsController";
+
+const postsRouter = Router();
+
+// Públicas
+
+postsRouter.get("/posts", validateOptionalJWT(), listPostsController);
+
+postsRouter.get("/posts/:slug", validateOptionalJWT(), getPostBySlugController);
+
+// Protegidas
+
+export default postsRouter;

--- a/src/test/controllers/posts.test.ts
+++ b/src/test/controllers/posts.test.ts
@@ -1,0 +1,168 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+import app from "../../app";
+import { cleanupTestData, createPost, createUser } from "../helpers";
+
+describe("Posts Routes", () => {
+	let authorId: string;
+	let adminToken: string;
+
+	beforeEach(async () => {
+		await cleanupTestData();
+
+		const author = await createUser({
+			email: "author@example.com",
+			password: "Password123",
+			role: "MASTER",
+		});
+
+		authorId = author.id;
+
+		const admin = await createUser({
+			email: "admin@example.com",
+			password: "Password123",
+			role: "ADMIN",
+		});
+
+		const adminAuth = await request(app)
+			.post("/users/authenticate")
+			.send({ email: admin.email, password: admin.password });
+
+		adminToken = adminAuth.body.token;
+	});
+
+	describe("GET /posts", () => {
+		it("should return only published posts without authentication", async () => {
+			await createPost({
+				title: "Published Post",
+				slug: "published-post",
+				status: "PUBLICADO",
+				authorId,
+			});
+
+			await createPost({
+				title: "Draft Post",
+				slug: "draft-post",
+				status: "RASCUNHO",
+				authorId,
+			});
+
+			const response = await request(app).get("/posts").expect(200);
+
+			expect(response.body.data.posts).toHaveLength(1);
+			expect(response.body.data.posts[0].slug).toBe("published-post");
+			expect(response.body.data.posts[0].status).toBe("PUBLICADO");
+		});
+
+		it("should force status to PUBLICADO when status=RASCUNHO is requested without authentication", async () => {
+			await createPost({
+				title: "Draft Post",
+				slug: "draft-post",
+				status: "RASCUNHO",
+				authorId,
+			});
+
+			const response = await request(app)
+				.get("/posts?status=RASCUNHO")
+				.expect(200);
+
+			expect(response.body.data.posts).toHaveLength(0);
+		});
+
+		it("should allow admin to filter drafts via status=RASCUNHO", async () => {
+			await createPost({
+				title: "Draft Post",
+				slug: "draft-post",
+				status: "RASCUNHO",
+				authorId,
+			});
+
+			await createPost({
+				title: "Published Post",
+				slug: "published-post",
+				status: "PUBLICADO",
+				authorId,
+			});
+
+			const response = await request(app)
+				.get("/posts?status=RASCUNHO")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.expect(200);
+
+			expect(response.body.data.posts).toHaveLength(1);
+			expect(response.body.data.posts[0].slug).toBe("draft-post");
+			expect(response.body.data.posts[0].status).toBe("RASCUNHO");
+		});
+
+		it("should return correct total and totalPages with pagination", async () => {
+			for (let i = 1; i <= 7; i++) {
+				await createPost({
+					title: `Published Post ${i}`,
+					slug: `published-post-${i}`,
+					status: "PUBLICADO",
+					authorId,
+				});
+			}
+
+			const response = await request(app)
+				.get("/posts?page=1&limit=5")
+				.expect(200);
+
+			expect(response.body.data.posts).toHaveLength(5);
+			expect(response.body.data.total).toBe(7);
+			expect(response.body.data.page).toBe(1);
+			expect(response.body.data.limit).toBe(5);
+			expect(response.body.data.totalPages).toBe(2);
+		});
+	});
+
+	describe("GET /posts/:slug", () => {
+		it("should return a published post", async () => {
+			await createPost({
+				title: "Published Post",
+				slug: "published-post",
+				status: "PUBLICADO",
+				authorId,
+			});
+
+			const response = await request(app)
+				.get("/posts/published-post")
+				.expect(200);
+
+			expect(response.body.data).toHaveProperty("slug", "published-post");
+			expect(response.body.data).toHaveProperty("status", "PUBLICADO");
+		});
+
+		it("should return 404 for a draft post without authentication", async () => {
+			await createPost({
+				title: "Draft Post",
+				slug: "draft-post",
+				status: "RASCUNHO",
+				authorId,
+			});
+
+			await request(app).get("/posts/draft-post").expect(404);
+		});
+
+		it("should return a draft post to an authenticated admin", async () => {
+			await createPost({
+				title: "Draft Post",
+				slug: "draft-post",
+				status: "RASCUNHO",
+				authorId,
+			});
+
+			const response = await request(app)
+				.get("/posts/draft-post")
+				.set("Authorization", `Bearer ${adminToken}`)
+				.expect(200);
+
+			expect(response.body.data).toHaveProperty("slug", "draft-post");
+			expect(response.body.data).toHaveProperty("status", "RASCUNHO");
+		});
+
+		it("should return 404 for a non-existent post", async () => {
+			await request(app).get("/posts/non-existent-post").expect(404);
+		});
+	});
+});


### PR DESCRIPTION
# Descrição

Esta PR expõe os serviços de consulta de posts via HTTP, completando a camada de controllers/rotas do blog.

**Mudanças realizadas:**

- Novo middleware `validateOptionalJWT`: decodifica o JWT quando presente e popula `req.user`, mas **nunca bloqueia** a requisição (token ausente ou inválido segue sem autenticação). Necessário porque as rotas são públicas, porém precisam saber se o chamador é `ADMIN` para liberar rascunhos.
- Controllers em `src/controllers/posts/`:
  - `listPostsController` — lê `page`, `limit`, `categorySlug`, `search`, `status` da query e passa `isAdmin` ao `ListPostsService`
  - `getPostBySlugController` — lê `:slug`, passa `isAdmin` ao `GetPostBySlugService`; mapeia `PostNotFoundError` → 404 e demais erros → 500
- Rotas públicas registradas em `postsRoutes.ts` e montadas em `controllers/index.ts`:
  - `GET /posts`
  - `GET /posts/:slug`
- Testes de integração cobrindo acesso anônimo vs. admin, forçar status `PUBLICADO` sem auth, rascunhos e paginação (`total` / `totalPages`)

**Motivação:** permitir leitura pública de posts publicados e, ao mesmo tempo, dar ao admin visibilidade de rascunhos sem transformar as rotas em endpoints autenticados obrigatórios.

**Dependências envolvidas:** `express`, `jsonwebtoken`, `@prisma/client` (`PostStatus`), `supertest`/`vitest` (testes). Os services `ListPostsService` e `GetPostBySlugService` (e factories) já existentes na issue #28.

Essa PR closes #29

Essa PR tem como dependências as tarefas #28

## Tipo de Alterações

Marque o tipo de alterações realizadas:

- [ ] Correção de bug (alteração que corrige um problema)
- [x] Novo recurso (adição de novas funcionalidades)
- [ ] Refatoração (uma mudança no código que não corrige um problema nem adiciona novas funcionalidades)
- [ ] Breaking change (correção ou nova funcionalidade que pode causar mau funcionamento de outras funcionalidades existentes)

## Como Testar

1. Subir o banco de teste e rodar a suíte:

```bash
npm run test:docker
```

(ou, com o DB de teste já no ar: `npm run test:run`)

2. Validar manualmente (servidor em `npm run start:dev`):

- `GET /posts` sem token → apenas posts `PUBLICADO`
- `GET /posts?status=RASCUNHO` sem token → lista vazia
- `GET /posts?status=RASCUNHO` com `Authorization: Bearer <token ADMIN>` → rascunhos
- `GET /posts/:slug` de post publicado → 200
- `GET /posts/:slug` de rascunho sem auth → 404
- `GET /posts/:slug` de rascunho com token ADMIN → 200
- `GET /posts?page=1&limit=5` → `data.total` e `data.totalPages` coerentes

## Checklist

- [x] O código segue as diretrizes de codificação do projeto
- [x] Realizei a revisão do meu próprio código
- [x] As alterações foram testadas localmente e passaram nos testes
- [x] Minhas mudanças não geram novos "warnings" ou erros no código existente